### PR TITLE
GCNV-31 eggd annotate excluded regions v1.0.0 bug fixes

### DIFF
--- a/resources/home/dnanexus/annotate_excluded_panel.py
+++ b/resources/home/dnanexus/annotate_excluded_panel.py
@@ -74,7 +74,7 @@ def read_data(args):
     exc_panel.columns = exc_panel_col_names
     # remove versioning in transcript
     exc_panel['transcript2'] = exc_panel['transcript'].str.replace(r'\..*', '')
-    # some excluded regions are intron so its just a dot and removing this 
+    # some excluded regions are intron so its just a dot and removing this
     # can cause matching issues
     exc_panel.loc[exc_panel['transcript2'].fillna('').eq(''), 'transcript2'] = '.'
 

--- a/resources/home/dnanexus/annotate_excluded_panel.py
+++ b/resources/home/dnanexus/annotate_excluded_panel.py
@@ -101,7 +101,7 @@ def read_data(args):
         panel.columns = panel_col_names
         # remove versioning in transcript and add it to new column named
     # transcript_stripped
-        panel['transcript_stripped'] = panel['transcript_stripped'].str.replace(r'\..*', '')
+        panel['transcript_stripped'] = panel['transcript'].str.replace(r'\..*', '')
 
 
     return exc_panel, panel, cds_gene

--- a/resources/home/dnanexus/annotate_excluded_panel.py
+++ b/resources/home/dnanexus/annotate_excluded_panel.py
@@ -72,6 +72,8 @@ def read_data(args):
                             args.excluded_panel
                             ))
     exc_panel.columns = exc_panel_col_names
+    # remove versioning in transcript
+    exc_panel['transcript']= exc_panel['transcript'].str.replace(r'\..*', '')
 
     cds_gene_col_names = ["Chr", "Start",
                         "End", "Gene_Symbol", "Transcript",
@@ -93,6 +95,8 @@ def read_data(args):
                 "Panel file '{}' does not contain "
                 "expected columns".format(args.panel))
         panel.columns = panel_col_names
+        # remove versioning in transcript
+        panel['transcript']= panel['transcript'].str.replace(r'\..*', '')
 
 
     return exc_panel, panel, cds_gene
@@ -155,8 +159,6 @@ def main():
         output_filename = excluded_name + "_" + panel_name + ".bed"
     else:
         output_filename = excluded_name + "_" + "annotated" + ".bed"
-
-    print(output_filename)
 
     df2.to_csv(
             output_filename,

--- a/resources/home/dnanexus/annotate_excluded_panel.py
+++ b/resources/home/dnanexus/annotate_excluded_panel.py
@@ -73,7 +73,7 @@ def read_data(args):
                             ))
     exc_panel.columns = exc_panel_col_names
     # remove versioning in transcript
-    exc_panel['transcript']= exc_panel['transcript'].str.replace(r'\..*', '')
+    exc_panel['transcript2'] = exc_panel['transcript'].str.replace(r'\..*', '')
 
     cds_gene_col_names = ["Chr", "Start",
                         "End", "Gene_Symbol", "Transcript",
@@ -96,7 +96,7 @@ def read_data(args):
                 "expected columns".format(args.panel))
         panel.columns = panel_col_names
         # remove versioning in transcript
-        panel['transcript']= panel['transcript'].str.replace(r'\..*', '')
+        panel['transcript2'] = panel['transcript'].str.replace(r'\..*', '')
 
 
     return exc_panel, panel, cds_gene
@@ -110,7 +110,7 @@ def main():
 
     if args.panel is not None:
         # get the transcripts in panel
-        panel_transcripts = list(panel['transcript'].unique())
+        panel_transcripts = list(panel['transcript2'].unique())
         # Add the dot for cases where its not exonic so they have a
         # dot instead of a transcript.
         panel_transcripts.append(".")
@@ -118,11 +118,11 @@ def main():
         # keep rows that have panel transcript in the exc_panel as exc_panel
         # has many transcript to gene
         exc_panel_transcript = exc_panel.loc[
-                            exc_panel["transcript"].isin(panel_transcripts)
+                            exc_panel["transcript2"].isin(panel_transcripts)
                             ]
+        exc_panel_transcript = exc_panel_transcript.drop(['transcript2'], axis=1)
     else:
         exc_panel_transcript = exc_panel
-
 
     # select excluded columns, HGNCID, transcript, exon
     exc_panel_transcript_subset = exc_panel_transcript[[

--- a/resources/home/dnanexus/annotate_excluded_panel.py
+++ b/resources/home/dnanexus/annotate_excluded_panel.py
@@ -74,6 +74,9 @@ def read_data(args):
     exc_panel.columns = exc_panel_col_names
     # remove versioning in transcript
     exc_panel['transcript2'] = exc_panel['transcript'].str.replace(r'\..*', '')
+    # some excluded regions are intron so its just a dot and removing this 
+    # can cause matching issues
+    exc_panel.loc[exc_panel['transcript2'].fillna('').eq(''), 'transcript2'] = '.'
 
     cds_gene_col_names = ["Chr", "Start",
                         "End", "Gene_Symbol", "Transcript",

--- a/resources/home/dnanexus/annotate_excluded_panel.py
+++ b/resources/home/dnanexus/annotate_excluded_panel.py
@@ -72,11 +72,12 @@ def read_data(args):
                             args.excluded_panel
                             ))
     exc_panel.columns = exc_panel_col_names
-    # remove versioning in transcript
-    exc_panel['transcript2'] = exc_panel['transcript'].str.replace(r'\..*', '')
+    # remove versioning in transcript and add it to new column named
+    # transcript_stripped
+    exc_panel['transcript_stripped'] = exc_panel['transcript'].str.replace(r'\..*', '')
     # some excluded regions are intron so its just a dot and removing this
     # can cause matching issues
-    exc_panel.loc[exc_panel['transcript2'].fillna('').eq(''), 'transcript2'] = '.'
+    exc_panel.loc[exc_panel['transcript_stripped'].fillna('').eq(''), 'transcript_stripped'] = '.'
 
     cds_gene_col_names = ["Chr", "Start",
                         "End", "Gene_Symbol", "Transcript",
@@ -98,8 +99,9 @@ def read_data(args):
                 "Panel file '{}' does not contain "
                 "expected columns".format(args.panel))
         panel.columns = panel_col_names
-        # remove versioning in transcript
-        panel['transcript2'] = panel['transcript'].str.replace(r'\..*', '')
+        # remove versioning in transcript and add it to new column named
+    # transcript_stripped
+        panel['transcript_stripped'] = panel['transcript_stripped'].str.replace(r'\..*', '')
 
 
     return exc_panel, panel, cds_gene
@@ -113,7 +115,7 @@ def main():
 
     if args.panel is not None:
         # get the transcripts in panel
-        panel_transcripts = list(panel['transcript2'].unique())
+        panel_transcripts = list(panel['transcript_stripped'].unique())
         # Add the dot for cases where its not exonic so they have a
         # dot instead of a transcript.
         panel_transcripts.append(".")
@@ -121,9 +123,9 @@ def main():
         # keep rows that have panel transcript in the exc_panel as exc_panel
         # has many transcript to gene
         exc_panel_transcript = exc_panel.loc[
-                            exc_panel["transcript2"].isin(panel_transcripts)
+                            exc_panel["transcript_stripped"].isin(panel_transcripts)
                             ]
-        exc_panel_transcript = exc_panel_transcript.drop(['transcript2'], axis=1)
+        exc_panel_transcript = exc_panel_transcript.drop(['transcript_stripped'], axis=1)
     else:
         exc_panel_transcript = exc_panel
 

--- a/src/eggd_annotate_excluded_regions.sh
+++ b/src/eggd_annotate_excluded_regions.sh
@@ -14,13 +14,15 @@ main() {
     # sometimes a panel bed file is not provided
     if [ -z "$panel_bed" ]; then
         echo "No panel bed file provided, so the gCNV excluded regions is annotated."
+        # -wao will keep regions that do and don't intersect
         bedtools intersect -b $cds_hgnc_path -a $excluded_regions_path -wao > excluded_genes.bed
         head excluded_genes.bed
         python3 annotate_excluded_panel.py -e excluded_genes.bed -r $excluded_regions_path -c $cds_gene_path
 
     else
         echo "Panel bed file is provided, so the gCNV excluded regions will be interested with panel bed file."
-        bedtools intersect -a $excluded_regions_path -b $panel_bed_path | sort | uniq > panel_excluded.bed
+        # -wa will keep the a (excluded file) start and end rather than the start and end of both files
+        bedtools intersect -a $excluded_regions_path -b $panel_bed_path -wa | sort | uniq > panel_excluded.bed
         head panel_excluded.bed
         # some panels may not be excluded so the panel_excluded.bed so have
         # an empty file outputted here.


### PR DESCRIPTION
- Remove transcript versions when matching between the cds and excluded_panel file.
- Bedtools intersect with argument `-wa` to have the start-end positions of the excluded regions rather then exon regions from the panel file.

Example of intersect:
Should be -
![Screenshot from 2022-08-24 15-31-02](https://user-images.githubusercontent.com/45298626/186445372-f44ec504-848e-495c-9f9a-b20d43d7007d.png)
Previously was - 
![Screenshot from 2022-08-24 15-30-05](https://user-images.githubusercontent.com/45298626/186445425-fcfb2079-f701-47ff-8eaf-6f738555e8cb.png)
To see the excluded region (black bar on top) and exons visually on track:
![Screenshot from 2022-08-24 11-17-13](https://user-images.githubusercontent.com/45298626/186445606-b53594d8-f3b2-42fc-a0fd-f9350011c805.png)
We just want the excluded start-end positions and associated exon, hence the use of `-wa`. More details of this is documented here -  https://cuhbioinformatics.atlassian.net/wiki/spaces/C/pages/2767126531/eggd+annotate+excluded+regions+v1.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_annotate_excluded_regions/3)
<!-- Reviewable:end -->
